### PR TITLE
Feat/#2 parking

### DIFF
--- a/src/main/java/gyeonggi/gyeonggifesta/config/RestTemplateConfig.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/config/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package gyeonggi.gyeonggifesta.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+
+	@Bean
+	public RestTemplate restTemplate() {
+		return new RestTemplate();
+	}
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/component/ParkingApiClient.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/component/ParkingApiClient.java
@@ -1,0 +1,216 @@
+package gyeonggi.gyeonggifesta.parking.component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import gyeonggi.gyeonggifesta.exception.BusinessException;
+import gyeonggi.gyeonggifesta.parking.exception.ParkingErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpStatusCodeException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ParkingApiClient {
+
+	private final RestTemplate restTemplate;
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	@Value("${open-api.parking.base-url:https://openapi.gg.go.kr}")
+	private String baseUrl;
+
+	@Value("${open-api.parking.service:ParkingPlace}")
+	private String serviceName;
+
+	@Value("${open-api.parking.key}")
+	private String apiKey;
+
+	@Value("${open-api.parking.page-size:500}")
+	private int defaultPageSize;
+
+	// ---------- Public API ----------
+	public List<JsonNode> fetchAllRows(String sigunNm) {
+		// 1차 시도 (기본)
+		try {
+			return fetch(sigunNm, defaultPageSize, BuildMode.ENCODE_ALL, HeaderMode.MINIMAL);
+		} catch (BusinessException e1) {
+			log.warn("[Fallback#1] 기본 호출 실패: {} - {}", e1.getClass().getSimpleName(), e1.getMessage());
+			// 2차 시도: 압축 비활성화
+			try {
+				return fetch(sigunNm, defaultPageSize, BuildMode.ENCODE_ALL, HeaderMode.NO_COMPRESSION);
+			} catch (BusinessException e2) {
+				log.warn("[Fallback#2] 압축 비활성화 실패: {} - {}", e2.getClass().getSimpleName(), e2.getMessage());
+				// 3차 시도: pSize 축소 + 인코딩 방식 변경
+				int small = Math.min(defaultPageSize, 50);
+				return fetch(sigunNm, small, BuildMode.ENCODE_QUERY_ONLY, HeaderMode.MINIMAL);
+			}
+		}
+	}
+
+	// ---------- Internal ----------
+	private enum BuildMode { ENCODE_ALL, ENCODE_QUERY_ONLY }
+	private enum HeaderMode { MINIMAL, NO_COMPRESSION }
+
+	private List<JsonNode> fetch(String sigunNm, int pageSize, BuildMode buildMode, HeaderMode headerMode) {
+		HttpStatusCode lastStatus = null;
+		String lastErrBody = null;
+
+		try {
+			int page = 1;
+			int total = Integer.MAX_VALUE;
+			List<JsonNode> rows = new ArrayList<>();
+
+			while ((page - 1) * pageSize < total) {
+				URI uri = (buildMode == BuildMode.ENCODE_ALL)
+					? buildUriEncodeAll(sigunNm, page, pageSize)
+					: buildUriEncodeQueryOnly(sigunNm, page, pageSize);
+
+				HttpHeaders headers = new HttpHeaders();
+				// 일부 게이트웨이는 Accept 헤더가 특정 값일 때만 정상 동작
+				headers.set(HttpHeaders.ACCEPT, "*/*");
+				headers.set(HttpHeaders.USER_AGENT, "Mozilla/5.0");
+				if (headerMode == HeaderMode.NO_COMPRESSION) {
+					// 압축 응답을 꺼서 RestTemplate/중간 프록시 이슈 회피
+					headers.set(HttpHeaders.ACCEPT_ENCODING, "identity");
+				}
+				HttpEntity<Void> entity = new HttpEntity<>(headers);
+
+				log.info("경기도 주차장 API 호출 URI = {}", uri);
+				ResponseEntity<String> res =
+					restTemplate.exchange(uri, HttpMethod.GET, entity, String.class);
+
+				lastStatus = res.getStatusCode();
+				String bodyStr = res.getBody();
+
+				if (!lastStatus.is2xxSuccessful() || bodyStr == null) {
+					log.error("HTTP 오류: status={}, body={}", lastStatus, bodyStr);
+					throw new BusinessException(ParkingErrorCode.API_REQUEST_FAILED);
+				}
+
+				JsonNode body = mapper.readTree(bodyStr);
+				ParseResult pr = parseAndCollect(body, rows);
+				if (pr.errorCode != null) {
+					// 예: ERROR-310 → 폴백 단계로 넘김
+					log.error("API 오류 code={} msg={}", pr.errorCode, pr.errorMessage);
+					throw new BusinessException(ParkingErrorCode.API_REQUEST_FAILED);
+				}
+				total = pr.total;
+
+				if (pr.pageRowCount == 0) break;
+				try {
+					Thread.sleep(700); // 0.7초 대기 (서버 과부하 방지)
+				} catch (InterruptedException ignored) {
+				}
+				page++;
+			}
+
+			log.info("API 수집 완료: totalRows={}", rows.size());
+			return rows;
+
+		} catch (HttpStatusCodeException httpEx) {
+			lastStatus = httpEx.getStatusCode();
+			lastErrBody = httpEx.getResponseBodyAsString();
+			log.error("HTTP 오류 status={} body={}", lastStatus, lastErrBody);
+			throw new BusinessException(ParkingErrorCode.API_REQUEST_FAILED);
+		} catch (BusinessException be) {
+			throw be;
+		} catch (Exception ex) {
+			log.error("주차장 API 기타 예외", ex);
+			throw new BusinessException(ParkingErrorCode.API_REQUEST_FAILED);
+		} finally {
+			if (lastStatus != null) {
+				log.warn("최종 응답 상태: {}", lastStatus);
+			}
+		}
+	}
+
+	private static class ParseResult {
+		int total = Integer.MAX_VALUE;
+		int pageRowCount = 0;
+		String errorCode;
+		String errorMessage;
+	}
+
+	private ParseResult parseAndCollect(JsonNode body, List<JsonNode> rows) {
+		ParseResult r = new ParseResult();
+
+		JsonNode arr = body.path("ParkingPlace");
+		if (!arr.isArray() || arr.size() < 2) {
+			// 일부 에러는 RESULT 루트로만 내려오기도 함
+			JsonNode result = body.path("RESULT");
+			if (result.isObject()) {
+				r.errorCode = result.path("CODE").asText(null);
+				r.errorMessage = result.path("MESSAGE").asText(null);
+			}
+			if (r.errorCode == null) {
+				r.errorCode = "INVALID";
+				r.errorMessage = "응답 형식 오류";
+			}
+			return r;
+		}
+
+		JsonNode head = arr.get(0).path("head");
+		if (head.isArray()) {
+			for (JsonNode h : head) {
+				String code = h.path("CODE").asText("");
+				String msg  = h.path("MESSAGE").asText("");
+				if (code.startsWith("ERROR")) {
+					r.errorCode = code;
+					r.errorMessage = msg;
+					return r;
+				}
+				if (h.has("list_total_count")) {
+					r.total = h.get("list_total_count").asInt(Integer.MAX_VALUE);
+				}
+			}
+		}
+
+		JsonNode rowNode = arr.get(1).path("row");
+		if (rowNode.isArray() && rowNode.size() > 0) {
+			rowNode.forEach(rows::add);
+			r.pageRowCount = rowNode.size();
+		}
+		return r;
+	}
+
+	// 전체 encode
+	private URI buildUriEncodeAll(String sigunNm, int page, int pageSize) {
+		return UriComponentsBuilder
+			.fromHttpUrl(baseUrl)
+			.pathSegment(serviceName)
+			.queryParam("KEY", apiKey)
+			.queryParam("Type", "json")
+			.queryParam("pIndex", page)
+			.queryParam("pSize", pageSize)
+			.queryParam("SIGUN_NM", sigunNm)
+			.encode(StandardCharsets.UTF_8)
+			.build()
+			.toUri();
+	}
+
+	// queryParam 인코딩만 신뢰(전체 encode 미적용) + SIGUN_NM 수동 인코딩 비교
+	private URI buildUriEncodeQueryOnly(String sigunNm, int page, int pageSize) {
+		// 수동 인코딩 값
+		String encSigun = URLEncoder.encode(sigunNm, StandardCharsets.UTF_8);
+		return UriComponentsBuilder
+			.fromHttpUrl(baseUrl + "/" + serviceName) // pathSegment + 전체 encode 생략
+			.queryParam("KEY", apiKey)
+			.queryParam("Type", "json")
+			.queryParam("pIndex", page)
+			.queryParam("pSize", pageSize)
+			.queryParam("SIGUN_NM", encSigun)
+			.build(false) // 전체 encode 비활성화
+			.toUri();
+	}
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/controller/ParkingInfoController.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/controller/ParkingInfoController.java
@@ -1,0 +1,32 @@
+package gyeonggi.gyeonggifesta.parking.controller;
+
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingDetailDto;
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingMapDto;
+import gyeonggi.gyeonggifesta.parking.service.ParkingInfoService;
+import gyeonggi.gyeonggifesta.util.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/auth/user/parking")
+@RequiredArgsConstructor
+public class ParkingInfoController {
+
+	private final ParkingInfoService service;
+
+	// 지도용 목록
+	@GetMapping("/map/{sigunNm}")
+	public ResponseEntity<Response<List<ParkingMapDto>>> map(@PathVariable String sigunNm) {
+		return Response.ok(service.getMap(sigunNm)).toResponseEntity();
+	}
+
+	// 상세
+	@GetMapping("/detail/{sigunNm}/{parkingId}")
+	public ResponseEntity<Response<ParkingDetailDto>> detail(@PathVariable String sigunNm,
+		@PathVariable String parkingId) {
+		return Response.ok(service.getDetail(sigunNm, parkingId)).toResponseEntity();
+	}
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingApiInfoResponse.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingApiInfoResponse.java
@@ -1,0 +1,135 @@
+package gyeonggi.gyeonggifesta.parking.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ParkingApiInfoResponse {
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Root {
+		@JsonProperty("ParkingPlace")
+		private List<Section> parkingPlace;
+
+		/** head 섹션 반환 (없으면 null) */
+		public Head getHead() {
+			if (parkingPlace == null) return null;
+			for (Section s : parkingPlace) {
+				if (s.head != null && !s.head.isEmpty()) return s.head.get(0);
+			}
+			return null;
+		}
+
+		/** row(실데이터 리스트) 반환 (없으면 null) */
+		public List<ParkingInfo> getRow() {
+			if (parkingPlace == null) return null;
+			for (Section s : parkingPlace) {
+				if (s.row != null) return s.row;
+			}
+			return null;
+		}
+
+		/** 결과코드/메시지 반환 (없으면 null) */
+		public Result getResult() {
+			Head h = getHead();
+			return h != null ? h.getResult() : null;
+		}
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Section {
+		private List<Head> head;
+		private List<ParkingInfo> row;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Head {
+		@JsonProperty("list_total_count")
+		private Integer listTotalCount;
+		@JsonProperty("RESULT")
+		private Result result;
+		@JsonProperty("api_version")
+		private String apiVersion;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Builder
+	public static class Result {
+		@JsonProperty("CODE")
+		private String code;     // "INFO-000" 정상
+		@JsonProperty("MESSAGE")
+		private String message;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@JsonIgnoreProperties(ignoreUnknown = true)
+	public static class ParkingInfo {
+		@JsonProperty("PARKPLC_MANAGE_NO") private String manageNo;
+		@JsonProperty("PARKPLC_NM")        private String name;
+		@JsonProperty("PARKPLC_DIV_NM")    private String division;
+		@JsonProperty("PARKPLC_TYPE")      private String type;
+		@JsonProperty("LOCPLC_ROADNM_ADDR")private String roadAddr;
+		@JsonProperty("LOCPLC_LOTNO_ADDR") private String lotnoAddr;
+		@JsonProperty("PARKNG_COMPRT_PLANE_CNT") private Integer totalCnt;
+
+		@JsonProperty("WKDAY_OPERT_BEGIN_TM") private String wkdayBegin; // "HH:mm"
+		@JsonProperty("WKDAY_OPERT_END_TM")   private String wkdayEnd;
+		@JsonProperty("SAT_OPERT_BEGIN_TM")   private String satBegin;
+		@JsonProperty("SAT_OPERT_END_TM")     private String satEnd;
+		@JsonProperty("HOLIDAY_OPERT_BEGIN_TM") private String holBegin;
+		@JsonProperty("HOLIDAY_OPERT_END_TM")   private String holEnd;
+
+		@JsonProperty("CHRG_INFO")              private String chargeInfo; // 유료/무료/혼합
+		@JsonProperty("PARKNG_BASIS_TM")        private Integer baseTime;
+		@JsonProperty("PARKNG_BASIS_USE_CHRG")  private Integer baseRate;
+		@JsonProperty("ADD_UNIT_TM")            private Integer addTime;
+		@JsonProperty("ADD_UNIT_TM2_WITHIN_USE_CHRG") private Integer addRate;
+		@JsonProperty("DAY1_PARKTK_USE_CHRG")   private Integer dayMax;
+		@JsonProperty("CONTCT_NO")              private String tel;
+
+		public String getParkingCode() { return manageNo; }
+		public String getParkingName() { return name; }
+		public String getAddress() {
+			return (roadAddr != null && !roadAddr.isBlank()) ? roadAddr : lotnoAddr;
+		}
+		public String getParkingTypeName() { return type; }     // 노상/노외
+		public String getOperationName()   { return division; } // 공영/민영/혼합
+		public String getTELNO() { return tel; }
+		public int    getTotalParkingCount() { return totalCnt == null ? 0 : totalCnt; }
+		public String getPayYn() { return "무료".equals(chargeInfo) ? "N" : "Y"; }
+		public String getNightPayYn() { return "N"; } // 미제공 → 기본 N
+
+		public String getWeekdayOpenTime()  { return wkdayBegin; } // "HH:mm"
+		public String getWeekdayCloseTime() { return wkdayEnd;   }
+		public String getWeekendOpenTime()  { return satBegin;   }
+		public String getWeekendCloseTime() { return satEnd;     }
+		public String getHolidayOpenTime()  { return holBegin;   }
+		public String getHolidayCloseTime() { return holEnd;     }
+
+		public String getSaturdayFeeName() { return chargeInfo; }
+		public String getHolidayFeeName()  { return chargeInfo; }
+
+		public int getBaseRate()        { return baseRate == null ? 0 : baseRate; }
+		public int getBaseTime()        { return baseTime == null ? 0 : baseTime; }
+		public int getAdditionalRate()  { return addRate  == null ? 0 : addRate; }
+		public int getAdditionalTime()  { return addTime  == null ? 0 : addTime; }
+		public int getDailyMaxRate()    { return dayMax   == null ? 0 : dayMax;  }
+	}
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingDetailDto.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingDetailDto.java
@@ -1,0 +1,30 @@
+package gyeonggi.gyeonggifesta.parking.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParkingDetailDto {
+	private String parkingId;
+	private String name;
+	private String division;        // PARKPLC_DIV_NM
+	private String type;            // PARKPLC_TYPE
+	private String roadAddress;
+	private String lotnoAddress;
+	private Integer slotCount;      // PARKNG_COMPRT_PLANE_CNT
+	private String weekdayStart;    // WKDAY_OPERT_BEGIN_TM
+	private String weekdayEnd;      // WKDAY_OPERT_END_TM
+	private String satStart;        // SAT_OPERT_BEGIN_TM
+	private String satEnd;          // SAT_OPERT_END_TM
+	private String holStart;        // HOLIDAY_OPERT_BEGIN_TM
+	private String holEnd;          // HOLIDAY_OPERT_END_TM
+	private String chargeInfo;      // CHRG_INFO
+	private Integer baseMinutes;    // PARKNG_BASIS_TM
+	private Integer baseCharge;     // PARKNG_BASIS_USE_CHRG
+	private Integer addUnitMinutes; // ADD_UNIT_TM
+	private Integer addUnitCharge;  // ADD_UNIT_TM2_WITHIN_USE_CHRG
+	private String phone;           // CONTCT_NO
+	private Double lat;             // REFINE_WGS84_LAT
+	private Double lon;             // REFINE_WGS84_LOGT
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingMapDto.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingMapDto.java
@@ -1,0 +1,15 @@
+package gyeonggi.gyeonggifesta.parking.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ParkingMapDto {
+	private String parkingId;
+	private String name;
+	private String roadAddress;
+	private String lotnoAddress;
+	private Double lat;
+	private Double lon;
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/exception/ParkingErrorCode.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/exception/ParkingErrorCode.java
@@ -1,0 +1,22 @@
+package gyeonggi.gyeonggifesta.parking.exception;
+
+import gyeonggi.gyeonggifesta.util.response.error_code.ErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ParkingErrorCode implements ErrorCode {
+	API_REQUEST_FAILED("PKG-001", HttpStatus.INTERNAL_SERVER_ERROR, "주차장 정보 API 호출 실패"),
+	INVALID_RESPONSE("PKG-002", HttpStatus.INTERNAL_SERVER_ERROR, "주차장 API 응답 형식 오류"),
+	NOT_FOUND("PKG-404", HttpStatus.NOT_FOUND, "대상이 존재하지 않습니다.");
+
+	private final String code;
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	ParkingErrorCode(String code, HttpStatus httpStatus, String message) {
+		this.code = code;
+		this.httpStatus = httpStatus;
+		this.message = message;
+	}
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoService.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoService.java
@@ -1,0 +1,11 @@
+package gyeonggi.gyeonggifesta.parking.service;
+
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingDetailDto;
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingMapDto;
+
+import java.util.List;
+
+public interface ParkingInfoService {
+	List<ParkingMapDto> getMap(String sigunNm);
+	ParkingDetailDto getDetail(String sigunNm, String parkingId);
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoServiceImpl.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoServiceImpl.java
@@ -1,0 +1,91 @@
+package gyeonggi.gyeonggifesta.parking.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import gyeonggi.gyeonggifesta.exception.BusinessException;
+import gyeonggi.gyeonggifesta.parking.component.ParkingApiClient;
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingDetailDto;
+import gyeonggi.gyeonggifesta.parking.dto.response.ParkingMapDto;
+import gyeonggi.gyeonggifesta.parking.exception.ParkingErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ParkingInfoServiceImpl implements ParkingInfoService {
+
+	private final ParkingApiClient client;
+
+	@Override
+	public List<ParkingMapDto> getMap(String sigunNm) {
+		List<JsonNode> rows = client.fetchAllRows(sigunNm);
+		return rows.stream()
+			.map(this::toMapDto)
+			.filter(d -> d.getLat() != null && d.getLon() != null) // 지도에서 쓸 수 있는 것만
+			.toList();
+	}
+
+	@Override
+	public ParkingDetailDto getDetail(String sigunNm, String parkingId) {
+		List<JsonNode> rows = client.fetchAllRows(sigunNm);
+		return rows.stream()
+			.filter(n -> parkingId.equals(asText(n, "PARKPLC_MANAGE_NO")))
+			.findFirst()
+			.map(this::toDetailDto)
+			.orElseThrow(() -> new BusinessException(ParkingErrorCode.NOT_FOUND));
+	}
+
+	// ====== mapping & safe converters ======
+	private ParkingMapDto toMapDto(JsonNode n) {
+		return ParkingMapDto.builder()
+			.parkingId(asText(n, "PARKPLC_MANAGE_NO"))
+			.name(asText(n, "PARKPLC_NM"))
+			.roadAddress(asText(n, "LOCPLC_ROADNM_ADDR"))
+			.lotnoAddress(asText(n, "LOCPLC_LOTNO_ADDR"))
+			.lat(asDouble(n, "REFINE_WGS84_LAT"))
+			.lon(asDouble(n, "REFINE_WGS84_LOGT"))
+			.build();
+	}
+
+	private ParkingDetailDto toDetailDto(JsonNode n) {
+		return ParkingDetailDto.builder()
+			.parkingId(asText(n, "PARKPLC_MANAGE_NO"))
+			.name(asText(n, "PARKPLC_NM"))
+			.division(asText(n, "PARKPLC_DIV_NM"))
+			.type(asText(n, "PARKPLC_TYPE"))
+			.roadAddress(asText(n, "LOCPLC_ROADNM_ADDR"))
+			.lotnoAddress(asText(n, "LOCPLC_LOTNO_ADDR"))
+			.slotCount(asInt(n, "PARKNG_COMPRT_PLANE_CNT"))
+			.weekdayStart(asText(n, "WKDAY_OPERT_BEGIN_TM"))
+			.weekdayEnd(asText(n, "WKDAY_OPERT_END_TM"))
+			.satStart(asText(n, "SAT_OPERT_BEGIN_TM"))
+			.satEnd(asText(n, "SAT_OPERT_END_TM"))
+			.holStart(asText(n, "HOLIDAY_OPERT_BEGIN_TM"))
+			.holEnd(asText(n, "HOLIDAY_OPERT_END_TM"))
+			.chargeInfo(asText(n, "CHRG_INFO"))
+			.baseMinutes(asInt(n, "PARKNG_BASIS_TM"))
+			.baseCharge(asInt(n, "PARKNG_BASIS_USE_CHRG"))
+			.addUnitMinutes(asInt(n, "ADD_UNIT_TM"))
+			.addUnitCharge(asInt(n, "ADD_UNIT_TM2_WITHIN_USE_CHRG"))
+			.phone(asText(n, "CONTCT_NO"))
+			.lat(asDouble(n, "REFINE_WGS84_LAT"))
+			.lon(asDouble(n, "REFINE_WGS84_LOGT"))
+			.build();
+	}
+
+	private static String asText(JsonNode n, String f) {
+		JsonNode v = n.get(f);
+		return (v == null || v.isNull()) ? null : v.asText();
+	}
+	private static Integer asInt(JsonNode n, String f) {
+		String t = asText(n, f);
+		if (t == null || t.isBlank()) return null;
+		try { return Integer.parseInt(t.replaceAll("[^0-9]", "")); } catch (Exception e) { return null; }
+	}
+	private static Double asDouble(JsonNode n, String f) {
+		String t = asText(n, f);
+		if (t == null || t.isBlank()) return null;
+		try { return Double.parseDouble(t); } catch (Exception e) { return null; }
+	}
+}


### PR DESCRIPTION
# [FEAT] 경기도 공공데이터 주차장 API 연동 및 DTO 매핑

## 🔎 작업 내용
- 경기도 공공데이터포털 **ParkingPlace** API 연동
  - `ParkingApiClient`: RestTemplate(`String.class` 수신 → Jackson 수동 파싱), `INFO-000/ERROR-*` 처리, 페이지 루프 수집(`pIndex`, `pSize`)
  - 403 완화: 페이지 사이 **Thread.sleep(700ms)**, `User-Agent`/`Referer` 헤더 추가
  - 폴백 전략: 압축 비활성화(`Accept-Encoding: identity`), pSize 축소(기본 500 → 폴백 50)
- 서비스/컨트롤러
  - `ParkingInfoService`/`ParkingInfoServiceImpl`: 목록/상세 매핑 로직
  - `ParkingInfoController`:
    - `GET /api/auth/user/parking/map/{sigunNm}` (지도용 목록)
    - `GET /api/auth/user/parking/detail/{sigunNm}/{parkingId}` (상세)
- DTO
  - `ParkingMapDto`, `ParkingDetailDto` 추가 (주소/좌표/요금/운영시간 등)
- 예외/응답 통합
  - `BusinessException` + `ParkingErrorCode(API_REQUEST_FAILED, INVALID_RESPONSE, NOT_FOUND)`
  - 공통 `Response<T>` 포맷으로 성공/실패 응답 일원화

## ➕ 이슈 링크
* Closes #2

## 🧪 테스트 방법
1. 환경 변수 설정  
   - `OPEN-API_PARKING_KEY` 유효 키 주입
2. 서버 실행 후 호출
   - `GET /api/auth/user/parking/map/수원시`
   - `GET /api/auth/user/parking/detail/수원시/{PARKPLC_MANAGE_NO}`
3. 기대 결과
   - 로그: `INFO ... API 수집 완료: totalRows=...`
   - 200 응답(JSON): DTO 필드 매핑 확인 (`name`, `lat`, `lon`, `chargeInfo` 등)
4. 실패 케이스 확인
   - 존재하지 않는 `sigunNm`/`parkingId` → `NOT_FOUND` 또는 `API_REQUEST_FAILED` 코드 반환
5. Rate-limit 확인
   - 짧은 주기로 연속 호출 시 403 가능 → 재호출 전 1초 텀 유지(루프 내 700ms 지연 포함)

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 수동 호출 테스트(수원시/용인시) 정상 응답
- [x] 예외/실패 응답이 `Response<T>` 규격과 일치
- [x] 로그 레벨 및 메시지 포맷 점검
- [x] 환경 변수 주입(키) 및 yml 설정 확인

## 📸 스크린샷 (선택)

