### PR TITLE
[FEAT] Member 도메인 구현(#9)

### DIFF
--- a/src/main/java/gyeonggi/gyeonggifesta/member/controller/MemberController.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/controller/MemberController.java
@@ -1,0 +1,63 @@
+package gyeonggi.gyeonggifesta.member.controller;
+
+import gyeonggi.gyeonggifesta.auth.custom.CustomUserDetails;
+import gyeonggi.gyeonggifesta.member.dto.request.InputFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.request.UpdateFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.response.InputFeatureRes;
+import gyeonggi.gyeonggifesta.member.dto.response.MemberInfoRes;
+import gyeonggi.gyeonggifesta.member.service.MemberService;
+import gyeonggi.gyeonggifesta.util.response.Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MemberController {
+
+	private final MemberService memberService;
+
+	/**
+	 * 유저 피처 입력
+	 *
+	 * @param userDetails 로그인된 유저
+	 * @param request     유저 정보
+	 * @return AT, RT
+	 */
+	@PostMapping("/auth/semi/feature")
+	public ResponseEntity<Response<InputFeatureRes>> inputFeature(
+		@AuthenticationPrincipal CustomUserDetails userDetails, @RequestBody InputFeatureReq request) {
+		InputFeatureRes response = memberService.inputFeature(userDetails, request);
+
+		return Response.ok(response).toResponseEntity();
+	}
+
+	/**
+	 * 유저 정보 업데이트
+	 *
+	 * @param request 새 유저 정보
+	 */
+	@PatchMapping("/auth/user/feature")
+	public ResponseEntity<Response<Void>> updateFeature(@RequestBody UpdateFeatureReq request) {
+		memberService.updateFeature(request);
+
+		return Response.ok().toResponseEntity();
+	}
+
+	@GetMapping("/auth/user/info")
+	public ResponseEntity<Response<MemberInfoRes>> getInfo() {
+		MemberInfoRes memberInfoRes = memberService.getMemberInfo();
+
+		return Response.ok(memberInfoRes).toResponseEntity();
+	}
+
+	@GetMapping("/auth/all-user/email/{email}")
+	public ResponseEntity<Response<Void>> checkEmailDup(@AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable String email) {
+		memberService.validEmail(userDetails, email);
+
+		return Response.ok().toResponseEntity();
+	}
+
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/dto/request/InputFeatureReq.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/dto/request/InputFeatureReq.java
@@ -1,0 +1,16 @@
+package gyeonggi.gyeonggifesta.member.dto.request;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+public class InputFeatureReq {
+
+	private String username;
+	private String gender;
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate birthday;
+	private String email;
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/dto/request/UpdateFeatureReq.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/dto/request/UpdateFeatureReq.java
@@ -1,0 +1,19 @@
+package gyeonggi.gyeonggifesta.member.dto.request;
+
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Data
+public class UpdateFeatureReq {
+
+	private String username;
+
+	@DateTimeFormat(pattern = "yyyy-MM-dd")
+	private LocalDate birthday;
+
+	private String gender;
+
+	private String email;
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/dto/response/InputFeatureRes.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/dto/response/InputFeatureRes.java
@@ -1,0 +1,12 @@
+package gyeonggi.gyeonggifesta.member.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class InputFeatureRes {
+
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/dto/response/MemberInfoRes.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/dto/response/MemberInfoRes.java
@@ -1,0 +1,18 @@
+package gyeonggi.gyeonggifesta.member.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberInfoRes {
+
+	private String verifyId;
+	private String username;
+	private String gender;
+	private String email;
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/entity/Member.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/entity/Member.java
@@ -7,6 +7,8 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.Period;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -50,4 +52,5 @@ public class Member extends BaseEntity {
 	public int getAge() {
 		return Period.between(this.birthDay, LocalDate.now()).getYears();
 	}
+
 }

--- a/src/main/java/gyeonggi/gyeonggifesta/member/service/MemberService.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/service/MemberService.java
@@ -1,0 +1,29 @@
+package gyeonggi.gyeonggifesta.member.service;
+
+import gyeonggi.gyeonggifesta.auth.custom.CustomUserDetails;
+import gyeonggi.gyeonggifesta.member.dto.request.InputFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.request.UpdateFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.response.InputFeatureRes;
+import gyeonggi.gyeonggifesta.member.dto.response.MemberInfoRes;
+
+public interface MemberService {
+
+	/**
+	 * 유저 피처 입력
+	 *
+	 * @param userDetails 로그인된 유저
+	 * @param request     유저 정보
+	 * @return AT, RT
+	 */
+	InputFeatureRes inputFeature(CustomUserDetails userDetails, InputFeatureReq request);
+
+	/**
+	 * 유저 정보 업데이트
+	 * @param request 새 유저 정보
+	 */
+	void updateFeature(UpdateFeatureReq request);
+
+	MemberInfoRes getMemberInfo();
+
+	void validEmail(CustomUserDetails userDetails, String email);
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/member/service/MemberServiceImpl.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/member/service/MemberServiceImpl.java
@@ -1,0 +1,125 @@
+package gyeonggi.gyeonggifesta.member.service;
+
+import gyeonggi.gyeonggifesta.auth.custom.CustomUserDetails;
+import gyeonggi.gyeonggifesta.auth.dto.LoginDto;
+import gyeonggi.gyeonggifesta.auth.exception.AuthErrorCode;
+import gyeonggi.gyeonggifesta.exception.BusinessException;
+import gyeonggi.gyeonggifesta.member.dto.request.InputFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.request.UpdateFeatureReq;
+import gyeonggi.gyeonggifesta.member.dto.response.InputFeatureRes;
+import gyeonggi.gyeonggifesta.member.dto.response.MemberInfoRes;
+import gyeonggi.gyeonggifesta.member.entity.Member;
+import gyeonggi.gyeonggifesta.member.enums.Role;
+import gyeonggi.gyeonggifesta.member.repository.MemberRepository;
+import gyeonggi.gyeonggifesta.util.jwt.JwtTokenProvider;
+import gyeonggi.gyeonggifesta.util.security.SecurityUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MemberServiceImpl implements MemberService{
+
+	private final MemberRepository memberRepository;
+	private final SecurityUtil securityUtil;
+	private final JwtTokenProvider jwtTokenProvider;
+
+
+	/**
+	 * 유저 피처 입력
+	 *
+	 * @param userDetails 로그인된 유저
+	 * @param request     유저 정보
+	 * @return AT, RT
+	 */
+	@Override
+	@Transactional
+	public InputFeatureRes inputFeature(CustomUserDetails userDetails, InputFeatureReq request) {
+
+		Member currentMember = securityUtil.getCurrentMember();
+
+		validRoleSemi(currentMember);
+
+		validEmail(userDetails, request.getEmail());
+
+		inputUserInfo(currentMember, request);
+		currentMember.setRole(Role.ROLE_USER);
+
+		jwtTokenProvider.deleteRefreshToken(currentMember.getVerifyId());
+
+		LoginDto updatedLoginDto = LoginDto.builder()
+			.verifyId(currentMember.getVerifyId())
+			.role(currentMember.getRole().name())
+			.email(currentMember.getEmail())
+			.build();
+
+		CustomUserDetails updatedUserDetails = CustomUserDetails.create(updatedLoginDto);
+
+		String accessToken = jwtTokenProvider.generateAccessToken(updatedUserDetails);
+		String refreshToken = jwtTokenProvider.generateRefreshToken(updatedUserDetails);
+
+		return InputFeatureRes.builder()
+			.accessToken(accessToken)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+	private void validRoleSemi(Member member) {
+		if (!member.getRole().equals(Role.ROLE_SEMI_USER)) {
+			throw new BusinessException(AuthErrorCode.INVALID_ROLE);
+		}
+	}
+
+	@Override
+	public void validEmail(CustomUserDetails userDetails, String email) {
+		String currentEmail = userDetails.getEmail();
+		if (currentEmail != null && currentEmail.equals(email)) {
+			return;
+		}
+
+		// 다른 사용자와 이메일 중복 검사
+		if (memberRepository.existsByEmail(email)) {
+			throw new BusinessException(AuthErrorCode.EMAIL_DUPLICATED);
+		}
+	}
+
+	private void inputUserInfo(Member member, InputFeatureReq request) {
+		member.setUsername(request.getUsername());
+		member.setGender(request.getGender());
+		member.setBirthDay(request.getBirthday());
+		member.setEmail(request.getEmail());
+	}
+
+	/**
+	 * 유저 정보 업데이트
+	 * @param request 새 유저 정보
+	 */
+	@Override
+	@Transactional
+	public void updateFeature(UpdateFeatureReq request) {
+		Member currentMember = securityUtil.getCurrentMember();
+
+		updateUserInfo(currentMember, request);
+	}
+
+	private void updateUserInfo(Member member, UpdateFeatureReq request) {
+		member.setUsername(request.getUsername());
+		member.setGender(request.getGender());
+		member.setBirthDay(request.getBirthday());
+		member.setEmail(request.getEmail());
+	}
+
+	@Override
+	public MemberInfoRes getMemberInfo() {
+
+		Member member = securityUtil.getCurrentMember();
+
+		return MemberInfoRes.builder()
+			.verifyId(member.getVerifyId())
+			.username(member.getUsername())
+			.gender(member.getGender())
+			.email(member.getEmail())
+			.build();
+	}
+}


### PR DESCRIPTION
## 🔎 작업 내용
- 컨트롤러/서비스/엔티티/DTO 구성
  - `MemberController`
    - `POST /api/auth/semi/feature` : 세미회원(ROLE_SEMI_USER) 기본정보 입력 → ROLE_USER 승격 + AT/RT 재발급
    - `PATCH /api/auth/user/feature` : 회원 정보 수정(이름/성별/생일/이메일)
    - `GET /api/auth/user/info` : 내 정보 조회
    - `GET /api/auth/all-user/email/{email}` : 이메일 중복 확인
- 예외/응답
  - 공통 예외처리

## ➕ 이슈 링크
* Closes #9 

## 🧪 테스트 방법 (노션 API 명세서 참고)
- 세미회원 → 정회원 전환(기본정보 입력)
- 내 정보 조회
- 회원 정보 수정
- 이메일 중복 확인

## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] Dev 토큰 발급 후 Member API 4종(Post/ Patch/ Get/ Get) 정상 동작
- [x] 세미→정회원 승격 시 RT 폐기 및 AT/RT 재발급 확인
- [x] 예외/실패 응답이 `Response<T>` 규격과 일치

## 📸 스크린샷 (선택)