### PR TITLE
Fix refresh token role claim serialization

### DIFF
--- a/src/main/java/gyeonggi/gyeonggifesta/util/jwt/JwtTokenProvider.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/util/jwt/JwtTokenProvider.java
@@ -107,10 +107,10 @@ public class JwtTokenProvider {
 		Member member = memberRepository.findByVerifyId(verifyId)
 				.orElseThrow(() -> new BusinessException(AuthErrorCode.USER_NOT_FOUND));
 
-		Map<String, Object> accessClaims = Map.of(
-				"email", member.getEmail(),
-				"role", member.getRole()
-		);
+                Map<String, Object> accessClaims = Map.of(
+                                "email", member.getEmail(),
+                                "role", member.getRole().name()
+                );
 
 		String newAccessToken = createToken(verifyId, now, accessExpiryDate, accessClaims);
 		String newRefreshToken = createToken(verifyId, now, refreshExpiryDate, null);


### PR DESCRIPTION
## Summary
- ensure refreshed access tokens set the role claim to the enum name so JWT parsing receives a string value

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69119c01fa1083298a999be0d0877bd7)