### PR TITLE
[REFACTOR] 주차장 API 전면 개편 + 전체 조회 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,9 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
+
 	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.batch:spring-batch-test'

--- a/src/main/java/gyeonggi/gyeonggifesta/config/CacheConfig.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/config/CacheConfig.java
@@ -1,0 +1,38 @@
+    package gyeonggi.gyeonggifesta.config;
+
+    import com.github.benmanes.caffeine.cache.Caffeine;
+    import org.springframework.cache.CacheManager;
+    import org.springframework.cache.caffeine.CaffeineCacheManager;
+    import org.springframework.context.annotation.Bean;
+    import org.springframework.context.annotation.Configuration;
+    import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+    import org.springframework.cache.annotation.EnableCaching;
+
+    import java.time.Duration;
+    import java.util.concurrent.Executor;
+
+    @Configuration
+    @EnableCaching
+    public class CacheConfig {
+
+        @Bean
+        public CacheManager cacheManager() {
+            CaffeineCacheManager m = new CaffeineCacheManager("parkingRows");
+            m.setCaffeine(Caffeine.newBuilder()
+                    .maximumSize(2000)                      // 시군별 rows 캐시 상한
+                    .expireAfterWrite(Duration.ofMinutes(10)) // 10분 TTL (원하면 5분)
+            );
+            return m;
+        }
+
+        @Bean(name = "parkingExecutor")
+        public Executor parkingExecutor() {
+            ThreadPoolTaskExecutor ex = new ThreadPoolTaskExecutor();
+            ex.setThreadNamePrefix("parking-");
+            ex.setCorePoolSize(8);   // CPU/트래픽 보고 조정
+            ex.setMaxPoolSize(16);
+            ex.setQueueCapacity(200);
+            ex.initialize();
+            return ex;
+        }
+    }

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/component/ParkingApiCache.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/component/ParkingApiCache.java
@@ -1,0 +1,21 @@
+package gyeonggi.gyeonggifesta.parking.component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ParkingApiCache {
+
+    private final ParkingApiClient client;
+
+    /** 시군별 전체 row를 10분 캐시 */
+    @Cacheable(value = "parkingRows", key = "#sigunNm", unless = "#result == null || #result.isEmpty()")
+    public List<JsonNode> fetchAllRowsCached(String sigunNm) {
+        return client.fetchAllRows(sigunNm);
+    }
+}

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/controller/ParkingInfoController.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/controller/ParkingInfoController.java
@@ -6,10 +6,7 @@ import gyeonggi.gyeonggifesta.parking.service.ParkingInfoService;
 import gyeonggi.gyeonggifesta.util.response.Response;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,16 +17,49 @@ public class ParkingInfoController {
 
 	private final ParkingInfoService service;
 
-	// 지도용 목록
+	// ===== 기존 시군 단위 =====
+	/** 지도용 목록(시군) */
 	@GetMapping("/map/{sigunNm}")
 	public ResponseEntity<Response<List<ParkingMapDto>>> map(@PathVariable String sigunNm) {
 		return Response.ok(service.getMap(sigunNm)).toResponseEntity();
 	}
 
-	// 상세
+	/** 상세(시군 + parkingId) */
 	@GetMapping("/detail/{sigunNm}/{parkingId}")
 	public ResponseEntity<Response<ParkingDetailDto>> detail(@PathVariable String sigunNm,
 															 @PathVariable String parkingId) {
 		return Response.ok(service.getDetail(sigunNm, parkingId)).toResponseEntity();
+	}
+
+	/** 목록(시군) + 옵션 필터 */
+	@GetMapping("/list/{sigunNm}")
+	public ResponseEntity<Response<List<ParkingMapDto>>> list(@PathVariable String sigunNm,
+															  @RequestParam(required = false) String q,
+															  @RequestParam(required = false) String paid, // Y or N
+															  @RequestParam(defaultValue = "false") boolean geoOnly) {
+		return Response.ok(service.getList(sigunNm, q, paid, geoOnly)).toResponseEntity();
+	}
+
+	// ===== 경기도 전체 보기(시군 없이) =====
+	/** 지도용 전체 */
+	@GetMapping("/map")
+	public ResponseEntity<Response<List<ParkingMapDto>>> mapAll(@RequestParam(required = false) String paid, // Y or N
+																@RequestParam(required = false) String q,
+																@RequestParam(defaultValue = "true") boolean geoOnly) {
+		return Response.ok(service.getMapAll(paid, q, geoOnly)).toResponseEntity();
+	}
+
+	/** 목록 전체 */
+	@GetMapping("/list")
+	public ResponseEntity<Response<List<ParkingMapDto>>> listAll(@RequestParam(required = false) String paid, // Y or N
+																 @RequestParam(required = false) String q,
+																 @RequestParam(defaultValue = "false") boolean geoOnly) {
+		return Response.ok(service.getListAll(paid, q, geoOnly)).toResponseEntity();
+	}
+
+	/** 상세 전체(시군 불문) */
+	@GetMapping("/detail/{parkingId}")
+	public ResponseEntity<Response<ParkingDetailDto>> detailGlobal(@PathVariable String parkingId) {
+		return Response.ok(service.getDetailGlobal(parkingId)).toResponseEntity();
 	}
 }

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingApiInfoResponse.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingApiInfoResponse.java
@@ -21,7 +21,6 @@ public class ParkingApiInfoResponse {
 		@JsonProperty("ParkingPlace")
 		private List<Section> parkingPlace;
 
-		/** head 섹션 반환 (없으면 null) */
 		public Head getHead() {
 			if (parkingPlace == null) return null;
 			for (Section s : parkingPlace) {
@@ -30,7 +29,6 @@ public class ParkingApiInfoResponse {
 			return null;
 		}
 
-		/** row(실데이터 리스트) 반환 (없으면 null) */
 		public List<ParkingInfo> getRow() {
 			if (parkingPlace == null) return null;
 			for (Section s : parkingPlace) {
@@ -39,7 +37,6 @@ public class ParkingApiInfoResponse {
 			return null;
 		}
 
-		/** 결과코드/메시지 반환 (없으면 null) */
 		public Result getResult() {
 			Head h = getHead();
 			return h != null ? h.getResult() : null;
@@ -92,14 +89,14 @@ public class ParkingApiInfoResponse {
 		@JsonProperty("LOCPLC_LOTNO_ADDR") private String lotnoAddr;
 		@JsonProperty("PARKNG_COMPRT_PLANE_CNT") private Integer totalCnt;
 
-		@JsonProperty("WKDAY_OPERT_BEGIN_TM") private String wkdayBegin; // "HH:mm"
+		@JsonProperty("WKDAY_OPERT_BEGIN_TM") private String wkdayBegin;
 		@JsonProperty("WKDAY_OPERT_END_TM")   private String wkdayEnd;
 		@JsonProperty("SAT_OPERT_BEGIN_TM")   private String satBegin;
 		@JsonProperty("SAT_OPERT_END_TM")     private String satEnd;
 		@JsonProperty("HOLIDAY_OPERT_BEGIN_TM") private String holBegin;
 		@JsonProperty("HOLIDAY_OPERT_END_TM")   private String holEnd;
 
-		@JsonProperty("CHRG_INFO")              private String chargeInfo; // 유료/무료/혼합
+		@JsonProperty("CHRG_INFO")              private String chargeInfo;
 		@JsonProperty("PARKNG_BASIS_TM")        private Integer baseTime;
 		@JsonProperty("PARKNG_BASIS_USE_CHRG")  private Integer baseRate;
 		@JsonProperty("ADD_UNIT_TM")            private Integer addTime;
@@ -117,9 +114,9 @@ public class ParkingApiInfoResponse {
 		public String getTELNO() { return tel; }
 		public int    getTotalParkingCount() { return totalCnt == null ? 0 : totalCnt; }
 		public String getPayYn() { return "무료".equals(chargeInfo) ? "N" : "Y"; }
-		public String getNightPayYn() { return "N"; } // 미제공 → 기본 N
+		public String getNightPayYn() { return "N"; }
 
-		public String getWeekdayOpenTime()  { return wkdayBegin; } // "HH:mm"
+		public String getWeekdayOpenTime()  { return wkdayBegin; }
 		public String getWeekdayCloseTime() { return wkdayEnd;   }
 		public String getWeekendOpenTime()  { return satBegin;   }
 		public String getWeekendCloseTime() { return satEnd;     }

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingMapDto.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/dto/response/ParkingMapDto.java
@@ -8,8 +8,14 @@ import lombok.Getter;
 public class ParkingMapDto {
 	private String parkingId;
 	private String name;
+	private String division;     // 공영/민영/혼합
+	private String type;         // 노상/노외
 	private String roadAddress;
 	private String lotnoAddress;
 	private Double lat;
 	private Double lon;
+
+	// 필터/표시용
+	private Integer slotCount;
+	private String  payYn;       // Y(유료/혼합) / N(무료)
 }

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoService.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoService.java
@@ -6,6 +6,13 @@ import gyeonggi.gyeonggifesta.parking.dto.response.ParkingMapDto;
 import java.util.List;
 
 public interface ParkingInfoService {
+	// 기존 시군 단위
 	List<ParkingMapDto> getMap(String sigunNm);
+	List<ParkingMapDto> getList(String sigunNm, String q, String paid, boolean geoOnly);
 	ParkingDetailDto getDetail(String sigunNm, String parkingId);
+
+	// 경기도 전체
+	List<ParkingMapDto> getMapAll(String paid, String q, boolean geoOnly);
+	List<ParkingMapDto> getListAll(String paid, String q, boolean geoOnly);
+	ParkingDetailDto getDetailGlobal(String parkingId);
 }

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoServiceImpl.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/service/ParkingInfoServiceImpl.java
@@ -2,33 +2,50 @@ package gyeonggi.gyeonggifesta.parking.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import gyeonggi.gyeonggifesta.exception.BusinessException;
-import gyeonggi.gyeonggifesta.parking.component.ParkingApiClient;
+import gyeonggi.gyeonggifesta.parking.component.ParkingApiCache;
 import gyeonggi.gyeonggifesta.parking.dto.response.ParkingDetailDto;
 import gyeonggi.gyeonggifesta.parking.dto.response.ParkingMapDto;
 import gyeonggi.gyeonggifesta.parking.exception.ParkingErrorCode;
+import gyeonggi.gyeonggifesta.parking.support.ParkingRegions;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Map;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
 public class ParkingInfoServiceImpl implements ParkingInfoService {
 
-	private final ParkingApiClient client;
+	private final ParkingApiCache cache;
 
+	// ========= 기존 시군 단위 =========
 	@Override
 	public List<ParkingMapDto> getMap(String sigunNm) {
-		List<JsonNode> rows = client.fetchAllRows(sigunNm);
+		List<JsonNode> rows = cache.fetchAllRowsCached(sigunNm);
 		return rows.stream()
-				.map(this::toMapDto)
-				.filter(d -> d.getLat() != null && d.getLon() != null) // 지도에서 쓸 수 있는 것만
+				.map(this::toSimpleDto)
+				.filter(d -> d.getLat() != null && d.getLon() != null)
+				.toList();
+	}
+
+	@Override
+	public List<ParkingMapDto> getList(String sigunNm, String q, String paid, boolean geoOnly) {
+		List<JsonNode> rows = cache.fetchAllRowsCached(sigunNm);
+		return applyFilters(rows.stream().map(this::toSimpleDto), q, paid, geoOnly)
+				.sorted(Comparator.comparing(ParkingMapDto::getName, Comparator.nullsLast(String::compareTo)))
 				.toList();
 	}
 
 	@Override
 	public ParkingDetailDto getDetail(String sigunNm, String parkingId) {
-		List<JsonNode> rows = client.fetchAllRows(sigunNm);
+		List<JsonNode> rows = cache.fetchAllRowsCached(sigunNm);
 		return rows.stream()
 				.filter(n -> parkingId.equals(asText(n, "PARKPLC_MANAGE_NO")))
 				.findFirst()
@@ -36,15 +53,92 @@ public class ParkingInfoServiceImpl implements ParkingInfoService {
 				.orElseThrow(() -> new BusinessException(ParkingErrorCode.NOT_FOUND));
 	}
 
-	// ====== mapping & safe converters ======
-	private ParkingMapDto toMapDto(JsonNode n) {
+	// ========= 경기도 전체 =========
+	@Override
+	public List<ParkingMapDto> getMapAll(String paid, String q, boolean geoOnly) {
+		return applyFilters(mergedAll(), q, paid, geoOnly)
+				.filter(d -> !geoOnly || (d.getLat() != null && d.getLon() != null))
+				.sorted(Comparator.comparing(ParkingMapDto::getName, Comparator.nullsLast(String::compareTo)))
+				.toList();
+	}
+
+	@Override
+	public List<ParkingMapDto> getListAll(String paid, String q, boolean geoOnly) {
+		return applyFilters(mergedAll(), q, paid, geoOnly)
+				.sorted(Comparator.comparing(ParkingMapDto::getName, Comparator.nullsLast(String::compareTo)))
+				.toList();
+	}
+
+	@Override
+	public ParkingDetailDto getDetailGlobal(String parkingId) {
+		for (String sigun : ParkingRegions.GYEONGGI) {
+			List<JsonNode> rows = cache.fetchAllRowsCached(sigun);
+			Optional<JsonNode> hit = rows.stream()
+					.filter(n -> parkingId.equals(asText(n, "PARKPLC_MANAGE_NO")))
+					.findFirst();
+			if (hit.isPresent()) return toDetailDto(hit.get());
+		}
+		throw new BusinessException(ParkingErrorCode.NOT_FOUND);
+	}
+
+	// ========= 내부 유틸 =========
+
+	/** 경기도 전 시군 합치기(중복은 관리번호로 제거) */
+	private Stream<ParkingMapDto> mergedAll() {
+		Map<String, ParkingMapDto> uniq = new ConcurrentHashMap<>();
+		ParkingRegions.GYEONGGI
+				.parallelStream()
+				.map(cache::fetchAllRowsCached)
+				.filter(Objects::nonNull)
+				.flatMap(List::stream)
+				.map(this::toSimpleDto)
+				.forEach(dto -> {
+					if (dto != null && dto.getParkingId() != null) {
+						uniq.put(dto.getParkingId(), dto);
+					}
+				});
+		return uniq.values().stream();
+	}
+
+	private static Stream<ParkingMapDto> applyFilters(Stream<ParkingMapDto> stream,
+													  String q, String paid, boolean geoOnly) {
+		String keyword = (q == null) ? null : q.trim().toLowerCase(Locale.ROOT);
+		String paidUpper = (paid == null) ? null : paid.trim().toUpperCase(Locale.ROOT);
+		return stream.filter(dto -> {
+			if (dto == null) return false;
+			if (geoOnly && (dto.getLat() == null || dto.getLon() == null)) return false;
+			if (paidUpper != null && !paidUpper.isEmpty()) {
+				if (!"Y".equals(paidUpper) && !"N".equals(paidUpper)) return false;
+				if (!paidUpper.equals(dto.getPayYn())) return false;
+			}
+			if (keyword != null && !keyword.isEmpty()) {
+				String name = dto.getName() == null ? "" : dto.getName();
+				String addr = (dto.getRoadAddress() != null) ? dto.getRoadAddress()
+						: (dto.getLotnoAddress() != null ? dto.getLotnoAddress() : "");
+				String s = (name + " " + addr).toLowerCase(Locale.ROOT);
+				return s.contains(keyword);
+			}
+			return true;
+		});
+	}
+
+	// ========= 매핑 =========
+
+	private ParkingMapDto toSimpleDto(JsonNode n) {
+		String chargeInfo = asText(n, "CHRG_INFO");
+		String payYn = "무료".equals(chargeInfo) ? "N" : "Y";
+
 		return ParkingMapDto.builder()
 				.parkingId(asText(n, "PARKPLC_MANAGE_NO"))
 				.name(asText(n, "PARKPLC_NM"))
+				.division(asText(n, "PARKPLC_DIV_NM"))
+				.type(asText(n, "PARKPLC_TYPE"))
 				.roadAddress(asText(n, "LOCPLC_ROADNM_ADDR"))
 				.lotnoAddress(asText(n, "LOCPLC_LOTNO_ADDR"))
 				.lat(asDouble(n, "REFINE_WGS84_LAT"))
 				.lon(asDouble(n, "REFINE_WGS84_LOGT"))
+				.slotCount(asInt(n, "PARKNG_COMPRT_PLANE_CNT"))
+				.payYn(payYn)
 				.build();
 	}
 
@@ -74,6 +168,7 @@ public class ParkingInfoServiceImpl implements ParkingInfoService {
 				.build();
 	}
 
+	// ========= safe converters =========
 	private static String asText(JsonNode n, String f) {
 		JsonNode v = n.get(f);
 		return (v == null || v.isNull()) ? null : v.asText();
@@ -81,7 +176,7 @@ public class ParkingInfoServiceImpl implements ParkingInfoService {
 	private static Integer asInt(JsonNode n, String f) {
 		String t = asText(n, f);
 		if (t == null || t.isBlank()) return null;
-		try { return Integer.parseInt(t.replaceAll("[^0-9]", "")); } catch (Exception e) { return null; }
+		try { return Integer.parseInt(t.replaceAll("[^\\d]", "")); } catch (Exception e) { return null; }
 	}
 	private static Double asDouble(JsonNode n, String f) {
 		String t = asText(n, f);

--- a/src/main/java/gyeonggi/gyeonggifesta/parking/support/ParkingRegions.java
+++ b/src/main/java/gyeonggi/gyeonggifesta/parking/support/ParkingRegions.java
@@ -1,0 +1,14 @@
+package gyeonggi.gyeonggifesta.parking.support;
+
+import java.util.List;
+
+public final class ParkingRegions {
+	private ParkingRegions() {}
+
+	public static final List<String> GYEONGGI = List.of(
+			"수원시","성남시","의정부시","안양시","부천시","광명시","평택시","동두천시","안산시",
+			"고양시","과천시","구리시","남양주시","오산시","시흥시","군포시","의왕시","하남시",
+			"용인시","파주시","이천시","안성시","김포시","화성시","광주시","양주시","포천시",
+			"여주시","연천군","가평군","양평군"
+	);
+}


### PR DESCRIPTION
## 🔎 작업 내용
- **주차장 API 전면 개편 + 전체 조회 추가**
  - (기존 유지) 시군 단위 조회
    - `GET /api/auth/user/parking/map/{sigunNm}` : 지도용(좌표 필수)
    - `GET /api/auth/user/parking/list/{sigunNm}` : 목록 + 선택 필터(`q`, `paid`, `geoOnly`)
    - `GET /api/auth/user/parking/detail/{sigunNm}/{parkingId}` : 상세
  - (신규) **경기도 전체 조회**
    - `GET /api/auth/user/parking/map` : 전 시군 합산 지도용(기본 `geoOnly=true`)
    - `GET /api/auth/user/parking/list` : 전 시군 합산 목록
    - `GET /api/auth/user/parking/detail/{parkingId}` : 전역 상세(시군 불문)
  - 필터 동작
    - `q` : 이름/주소 부분일치(대소문자 무시)
    - `paid` : `Y`(유료/혼합) / `N`(무료) — 오픈API `CHRG_INFO` 기반 매핑
    - `geoOnly` : `true`면 좌표(`lat`,`lon`) 없는 항목 제외
  - 정렬 규칙: 이름 오름차순(`nullsLast`)
- **성능 개선(캐시 적용)**
  - Caffeine 캐시 도입(10분 TTL): 시군별 원본 rows 캐싱
    - `ParkingApiCache.fetchAllRowsCached(sigunNm)`에 `@Cacheable`
    - 서비스 레이어는 **`ParkingApiClient` → `ParkingApiCache`** 사용
  - 시군 병렬 수집 후 관리번호(`PARKPLC_MANAGE_NO`)로 중복 제거
  - 콜드 스타트 이후 전체 조회 응답 속도 대폭 개선
- **구성/코드 변경**
  - `CacheConfig` 추가: Caffeine CacheManager(`parkingRows`), `parkingExecutor`(8~16)
  - `ParkingInfoServiceImpl` :
    - 전체 조회/전역 상세 로직 추가
    - 필터 유틸(`applyFilters`) 공통화
    - 캐시 사용으로 외부 호출 최소화
  - DTO 보강
    - `ParkingMapDto` : `division`, `type`, `slotCount`, `payYn` 추가
      - `payYn`은 `CHRG_INFO`가 `"무료"`면 `N`, 그 외 `Y`
- **호환성**
  - 기존 엔드포인트/응답 래퍼(`Response<T>`) 완전 유지
  - 추가 엔드포인트는 기존 구조와 동일 스키마 반환

## ➕ 이슈 링크
* Closes #27 


## 🧪 테스트 방법(노션 API 명세서 참고)


## ✅ 체크리스트
- [x] 빌드 성공 (`./gradlew clean build`)
- [x] 주요 기능 수동 테스트 완료
- [x] 예외/실패 응답 형식 일관성 확인

## 📸 스크린샷 (선택)

